### PR TITLE
MsMedia Panel css position set back to fixed, but can change to absolute on showPanel

### DIFF
--- a/js/ca/ca.genericpanel.js
+++ b/js/ca/ca.genericpanel.js
@@ -60,16 +60,16 @@ var caUI = caUI || {};
 		// --------------------------------------------------------------------------------
 		// Define methods
 		// --------------------------------------------------------------------------------
-		that.showPanel = function(url, onCloseCallback) {
+		that.showPanel = function(url, onCloseCallback='', position='fixed') {
 			that.setZoom(that.allowMobileSafariZooming);
 			that.isChanging = true;
-			
 			
 			if (that.center) {
 				jQuery('#' + that.panelID).css("top", ((jQuery(window).height() - jQuery('#' + that.panelID).height())/2) + "px");
 				jQuery('#' + that.panelID).css("left", ((jQuery(window).width() - jQuery('#' + that.panelID).width())/2) + "px");
 			}
 			
+			jQuery('#' + that.panelID).css('position', position);
 			jQuery('#' + that.panelID).fadeIn(that.panelTransitionSpeed, function() { that.isChanging = false; });
 			
 			if (that.useExpose) { 

--- a/themes/morphosource/views/MediaCart/cart_html.php
+++ b/themes/morphosource/views/MediaCart/cart_html.php
@@ -21,7 +21,7 @@
 				$vs_display .= "<div class='mediaCartTools'>";
 				$vs_display .= "<div style='float:right;'>".caNavLink($this->request, _t("<i class='fa fa-times-circle'></i>"), "", "", "MediaCart", "Remove", array("media_file_id" => $q_items->get("media_file_id")), array("title" => _t("remove from cart")))."</div>";
 				#$vs_display .= caNavLink($this->request, _t("<i class='fa fa-download'></i>"), "", "Detail", "MediaDetail", "DownloadMedia", array("media_file_id" => $q_items->get("media_file_id"), "media_id" => $q_items->get("media_id"), "download" => 1), array("title" => _t("download")));
-				$vs_display .= "<a href='#' onclick='msMediaPanel.showPanel(\"".caNavUrl($this->request, 'Detail', 'MediaDetail', 'DownloadMediaSurvey', array("media_id" => $q_items->get("media_id"), "media_file_id" => $q_items->get("media_file_id"), "download_action" => "DownloadMedia"))."\"); return false;' title='download'>"._t("<i class='fa fa-download'></i>")."</a>";
+				$vs_display .= "<a href='#' onclick='msMediaPanel.showPanel(\"".caNavUrl($this->request, 'Detail', 'MediaDetail', 'DownloadMediaSurvey', array("media_id" => $q_items->get("media_id"), "media_file_id" => $q_items->get("media_file_id"), "download_action" => "DownloadMedia"))."\", \"\", \"absolute\"); return false;' title='download'>"._t("<i class='fa fa-download'></i>")."</a>";
 		
 				$vs_display .= "</div>";
 				$vs_display .= "<div class='projectMedia'>";
@@ -64,7 +64,7 @@
 <?php
 			print caNavLink($this->request, _t("Clear Cart"), "button buttonLarge", "", "MediaCart", "clearCart", array("set_id" => $vn_set_id))." ";
 			#print caNavLink($this->request, _t("Download all files & metadata"), "button buttonLarge", "", "MediaCart", "downloadCart", array("set_id" => $vn_set_id, "download" => 1))." ";
-			print "<a href='#' class='button buttonLarge' onclick='msMediaPanel.showPanel(\"".caNavUrl($this->request, 'Detail', 'MediaDetail', 'DownloadMediaSurvey', array("set_id" => $vn_set_id))."\"); return false;' title='download'>"._t("Download all files & metadata")."</a> ";
+			print "<a href='#' class='button buttonLarge' onclick='msMediaPanel.showPanel(\"".caNavUrl($this->request, 'Detail', 'MediaDetail', 'DownloadMediaSurvey', array("set_id" => $vn_set_id))."\", \"\", \"absolute\"); return false;' title='download'>"._t("Download all files & metadata")."</a> ";
 			print caNavLink($this->request, _t("Download only metadata"), "button buttonLarge", "", "MediaCart", "downloadCartMd", array("set_id" => $vn_set_id, "download" => 1));
 ?>
 		</div>


### PR DESCRIPTION
MsMediaPanel is used both for the pop-in pre-download user survey and the 3D media viewer. In an earlier commit, I changed the css position to 'absolute' so that in a small browser window, a user can scroll to the bottom of the pre-download user survey. But this caused unwanted scroll bars to appear when using the 3D media viewer. I changed the default css position back to fixed, but made it possible to use absolute position on invoking the media panel. 