### PR TITLE
Improved visual look and feel of media and specimen public pages, added 50 character minimum for download requests

### DIFF
--- a/app/conf/default_media_icons.conf
+++ b/app/conf/default_media_icons.conf
@@ -49,6 +49,7 @@ document = {
 	160x120 = 3dIcon160.jpg,
 	170x120 = 3dIcon170.jpg,
 	180x120 = 3dIcon180.jpg,
+	190x190 = 3dIcon190.jpg,
 	240x120 = 3dIcon240.jpg,
 	400x200 = 3dIcon400.jpg,
 	580x200 = 3dIcon580.jpg,

--- a/themes/morphosource/css/morphosource.css
+++ b/themes/morphosource/css/morphosource.css
@@ -1221,9 +1221,6 @@ input.lookupBg, textarea.lookupBg, #formArea input.lookupBg{
 }
 
 #mediaDetail #mediaDetailImageScrollArea{
-	max-height:450px;
-	overflow-y:auto;
-	margin-bottom:10px;
 }
 #mediaDetail #mediaDetailImageScrollArea .mediaDetailImage{
 	min-height:190px;

--- a/themes/morphosource/views/Detail/ms_specimens_detail_html.php
+++ b/themes/morphosource/views/Detail/ms_specimens_detail_html.php
@@ -6,38 +6,53 @@
 	$t_specimen = new ms_specimens($t_specimen->get("specimen_id"));
 	$vs_specimen_name = $t_specimen->getSpecimenName();
 ?>
+
 <div class="blueRule"><!-- empty --></div>
 <?php
 	$vs_back_link = "";
 	switch(ResultContext::getLastFind($this->request, "ms_specimens")){
 		case "specimen_browse":
-			$vs_back_link = caNavLink($this->request, _t("Back"), 'button buttonLarge', '', 'Browse', 'Index', array(), array('id' => 'back'));
+			$vs_back_link = caNavLink($this->request, _t("Back To Browse"), 'button buttonMedium', '', 'Browse', 'Index', array(), array('id' => 'back'));
 		break;
 		# ----------------------------------
 		case "basic_search":
-			$vs_back_link = caNavLink($this->request, _t("Back"), 'button buttonLarge', '', 'Search', 'Index', array(), array('id' => 'back'));
+			$vs_back_link = caNavLink($this->request, _t("Back To Search"), 'button buttonMedium', '', 'Search', 'Index', array(), array('id' => 'back'));
 		break;
 		# ----------------------------------
 	}
-	if (($this->getVar('is_in_result_list'))) {
-		if ($this->getVar('next_id') > 0) {
-			print "<div style='float:right; padding:10px 0px 0px 15px;'>".caNavLink($this->request, _t("Next"), 'button buttonLarge', 'Detail', 'SpecimenDetail', 'Show', array('specimen_id' => $this->getVar('next_id')), array('id' => 'next'))."</div>";
-		}
-		print "<div style='float:right; padding:10px 0px 0px 15px;'>".$vs_back_link."</div>";
-		if ($this->getVar('previous_id')) {
-			print "<div style='float:right; padding:10px 0px 0px 15px;'>".caNavLink($this->request, _t("Previous"), 'button buttonLarge', 'Detail', 'SpecimenDetail', 'Show', array('specimen_id' => $this->getVar('previous_id')), array('id' => 'previous'))."</div>";
-		}
-	}
 ?>
-<H1 class="specimenDetailTitle">
-<?php 
-	print _t("Specimen: ").$vs_specimen_name;
+
+<div style='overflow:hidden;'>
+<?php
+	print "<div style=''>";
+	print "<H1 class='specimenDetailTitle'>"._t("Specimen: ").$vs_specimen_name."</H1>";
+	print "</div>";
+?>
+</div>
+<div class="tealRule"><!-- empty --></div>
+<div style='overflow:hidden;'>
+<?php
 	if($vs_uuid_id = $t_specimen->get("uuid")){
-		print "<br/><a href='https://www.idigbio.org/portal/records/".$vs_uuid_id."' target='_blank' class='button buttonSmall' style='margin-top:3px;'>View specimen on iDigBio</a><br/>";
+		print "<div style='float:left; padding:10px 0px 0px 0px; margin-bottom: 15px; margin-right: 15px;'><a href='https://www.idigbio.org/portal/records/".$vs_uuid_id."' target='_blank' class='button buttonMedium' style=''>View specimen on iDigBio</a></div>";
 	}
+	if($vb_show_edit_link){
+		print "<div style='float:left; padding:10px 0px 0px 0px; margin-bottom: 15px;'>".caNavLink($this->request, _t("Edit Specimen"), "button buttonMedium", "MyProjects", "Specimens", "form", array("specimen_id" => $t_specimen->get("specimen_id"), "select_project_id" => $t_specimen->get("project_id")))."</div>";
+	}
+	if (($this->getVar('is_in_result_list'))) {
+		// print "<div class='blueRule'><!-- empty --></div>";
+		// print "<H1 class=''>Search Result</H1>";
+		print "<div style='float:right; padding:10px 0px 0px 0px; margin-bottom: 15px;'>".$vs_back_link."</div>";
+		if ($this->getVar('next_id') > 0) {
+			print "<div style='float:right; padding:10px 0px 0px 0px; margin-bottom: 15px; margin-right: 15px;'>".caNavLink($this->request, _t("Next Result"), 'button buttonMedium', 'Detail', 'SpecimenDetail', 'Show', array('specimen_id' => $this->getVar('next_id')), array('id' => 'next'))."</div>";
+		}
 		
+		if ($this->getVar('previous_id')) {
+			print "<div style='float:right; padding:10px 0px 0px 0px; margin-bottom: 15px; margin-right: 15px;'>".caNavLink($this->request, _t("Previous Result"), 'button buttonMedium', 'Detail', 'SpecimenDetail', 'Show', array('specimen_id' => $this->getVar('previous_id')), array('id' => 'previous'))."</div>";
+		}
+	}
 ?>
-</H1>
+</div>
+
 <div id="specimenDetail">
 <?php
 	if($t_specimen->get("specimen_id")){
@@ -45,7 +60,7 @@
 		$t_project = new ms_projects($t_specimen->get("project_id"));
 		if($t_project->get("publication_status")){
 ?>
-		<div class="tealRule"><!-- empty --></div>
+		
 		<H2>Project</H2>
 			<div class="unit">
 <?php
@@ -56,7 +71,6 @@
 		}
 
 ?>
-		<div class="tealRule"><!-- empty --></div>
 <?php
 		if(is_array($va_bib_citations) && sizeof($va_bib_citations)){
 ?>
@@ -73,9 +87,6 @@
 			}
 			print "</div><!-- end unit --></div><!-- end specimenDetailBibContainer -->";
 			print "<div id='specimenDetailInfoContainer'>";
-		}
-		if($vb_show_edit_link){
-			print "<div style='float:right; padding:0px 0px 0px 15px;'>".caNavLink($this->request, _t("Edit"), "button buttonSmall", "MyProjects", "Specimens", "form", array("specimen_id" => $t_specimen->get("specimen_id"), "select_project_id" => $t_specimen->get("project_id")))."</div>";
 		}
 ?>
 		<H2>Specimen Information</H2>
@@ -190,7 +201,7 @@
 ?>
 		<div class="tealRule" style="clear:both;"><!-- empty --></div>
 			<H2>Specimen Media</H2>
-			<div id="specimenMediaList" class="unit">
+			<div class="unit">
 <?php
 			$va_options = array('versions' => array('preview190'), 'published' => true);
 			if($this->request->isLoggedIn()){
@@ -200,23 +211,21 @@
 			if (is_array($va_media_list) && sizeof($va_media_list)) {
 				$vn_media_output = false;
 				foreach($va_media_list as $vn_media_id => $va_media_info) {
-					if($va_media_info["numFiles"]){
-						$vn_media_output = true;
-						$t_media = new ms_media($vn_media_id);
-						$vs_side = $t_media->getChoiceListValue("side", $va_media_info['side']);
-				
-						print '<div class="specimenMediaListContainer">';
-						if (!($vs_media_tag = $va_media_info['media']['preview190'])) {
-							$vs_media_tag = "<div class='projectMediaPlaceholder'> </div>";
-						}
-						print "<div class='specimenMediaListSlide'>".caNavLink($this->request, $vs_media_tag, "", "Detail", "MediaDetail", "Show", array("media_id" => $vn_media_id))."</div>";
-						print caNavLink($this->request, "M".$vn_media_id, "blueText", "Detail", "MediaDetail", "Show", array("media_id" => $vn_media_id)).", ".$va_media_info["numFiles"]." file".(($va_media_info["numFiles"] == 1) ? "" : "s")."<br/>";
-						if($va_media_info['title']){
-							print $va_media_info['title']."<br/>";
-						}
-						print (($vs_side && (strtolower($vs_side) != 'unknown')) ? " ({$vs_side})" : "").(($vs_element = $va_media_info['element']) ? " ({$vs_element})" : "");
-						print "</div><!-- end specimenMediaListContainer -->\n";
+					$vn_media_output = true;
+					$t_media = new ms_media($vn_media_id);
+					$vs_side = $t_media->getChoiceListValue("side", $va_media_info['side']);
+			
+					print '<div class="specimenMediaListContainer">';
+					if (!($vs_media_tag = $va_media_info['media']['preview190'])) {
+						$vs_media_tag = "<div class='projectMediaPlaceholder'> </div>";
 					}
+					print "<div class='specimenMediaListSlide' style='height: 190px;'>".caNavLink($this->request, $vs_media_tag, "", "Detail", "MediaDetail", "Show", array("media_id" => $vn_media_id))."</div>";
+					print caNavLink($this->request, "M".$vn_media_id, "blueText", "Detail", "MediaDetail", "Show", array("media_id" => $vn_media_id)).", ".$va_media_info["numFiles"]." file".(($va_media_info["numFiles"] == 1) ? "" : "s")."<br/>";
+					if($va_media_info['title']){
+						print $va_media_info['title']."<br/>";
+					}
+					print (($vs_side && (strtolower($vs_side) != 'unknown')) ? " ({$vs_side})" : "").(($vs_element = $va_media_info['element']) ? " ({$vs_element})" : "");
+					print "</div><!-- end specimenMediaListContainer -->\n";
 				}
 			}
 			if(!$vn_media_output){

--- a/themes/morphosource/views/MyProjects/Specimens/form_html.php
+++ b/themes/morphosource/views/MyProjects/Specimens/form_html.php
@@ -121,7 +121,7 @@ if (!$this->request->isAjax() && $t_item->get("specimen_id")) {
 					}
 					$t_project = new ms_projects();
 					if(($va_media_info['project_id'] == $this->getVar("project_id")) || ($t_project->isMember($this->request->user->get("user_id"), $va_media_info['project_id']))){
-						print "<div class='specimenMediaListSlide'>".caNavLink($this->request, $vs_media_tag, "", "MyProjects", "Media", "mediaInfo", array("media_id" => $vn_media_id))."</div>";
+						print "<div class='specimenMediaListSlide' style='height: 190px;'>".caNavLink($this->request, $vs_media_tag, "", "MyProjects", "Media", "mediaInfo", array("media_id" => $vn_media_id))."</div>";
 						print "<span class='mediaID'>".caNavLink($this->request, "M".$vn_media_id, "", "MyProjects", "Media", "mediaInfo", array("media_id" => $vn_media_id))."</span>, ";
 					}else{
 						$vb_read_only_access = false;


### PR DESCRIPTION
A number of changes included here, addressing Jira issue MR-298 and other things:

* The empty gray box thumbnail image no longer displays at a different resolution from customized media preview images
* Specimen public and private pages now displays media groups without media files 
* Media group public pages have an edit button regardless of whether media files are present or whether a media group is associated with a specimen
* Media group public pages where media groups don't have media files now look visually more similar to media group public pages of media groups with media files
* For specimen and media public pages, moved the search control buttons under the title header, changed button text to be more explicit
* For specimen and media public pages, moved the edit specimen/media buttons under the header
* For media public pages, moved the download all media/request download/etc buttons under the header
* For media public pages, revamped appearance of download request menu and added a minimum 50 character requirement for download requests
* Media public page media files no longer scroll within a subframe, but extend the entire page length
* Because some media groups may have some media files with open download and some with restricted download, the following button text on media public pages has been changed: "Request Download of Media" to "Request Download of Restricted Media", "Access to Media Pending" to "Access to Restricted Media Pending", "You May Not Download This Media" to "Access to Restricted Media Denied" 
* Removed the 'citation elements' link and pop-in box at the top of media pages because it is redundant and often styles badly
* Changed header "Scan Information" (listing media group metadata) to "Media Group Information"