### PR TITLE
Revamped ways of getting media view/download statistics

### DIFF
--- a/app/controllers/StatsController.php
+++ b/app/controllers/StatsController.php
@@ -27,9 +27,12 @@
  */
  
  	require_once(__CA_LIB_DIR__."/core/Error.php");
+ 	require_once(__CA_MODELS_DIR__."/ms_media.php");
+ 	require_once(__CA_MODELS_DIR__."/ms_media_files.php");
  	require_once(__CA_MODELS_DIR__."/ms_projects.php");
  	require_once(__CA_MODELS_DIR__."/ms_specimens.php");
  	require_once(__CA_APP_DIR__.'/helpers/morphoSourceHelpers.php');
+ 	require_once(__CA_LIB_DIR__.'/core/Parsers/ZipStream.php');
  
  	class StatsController extends ActionController {
  		# -------------------------------------------------------
@@ -119,6 +122,11 @@
 				$va_specimen_info = array();
 				$this->opo_specimen->load($pn_specimen_id);
 				$va_all_media_ids = $this->opo_specimen->getSpecimenMediaIDs();
+				$va_pub_media_ids = $this->opo_specimen->getSpecimenMediaIDs(
+					$pn_specimen_id, 
+					array("published" => true));
+				$vn_num_unpub_media = 
+					sizeof($va_all_media_ids) - sizeof($va_pub_media_ids);
 				if(sizeof($va_all_media_ids)){
 					# --- filter out any unpublished media where user does not have access to project
 					$q_media_check = $o_db->query("SELECT media_id, project_id, published from ms_media where media_id IN (".join(", ", $va_all_media_ids).")");
@@ -134,6 +142,7 @@
 					$va_specimen_info = array("specimen_name" => $this->opo_specimen->getSpecimenName(),
 												"specimen_views" => $this->opo_specimen->numViews(),
 												"num_specimen_media" => sizeof($va_all_media_ids),
+												"num_specimen_media_unpublished" => $vn_num_unpub_media,
 												"num_specimen_media_no_access" => sizeof($va_all_media_ids) - sizeof($va_media_checked_ids)
 											);
 					$this->view->setVar("specimen_info", $va_specimen_info);
@@ -333,291 +342,110 @@
 
  		}
  		# -------------------------------------------------------
- 		 function downloadSummary() {
-			$va_filtered_specimen_ids = explode(",", $this->request->getParameter('specimen_ids', pString));
-			$va_specimen_info = array();
-			# --- get list of available projects for user
-			$va_projects = $this->opo_project->getProjectsForMember($this->request->user->get("user_id"));
-			$o_db = new Db();
-			$output_rows = array();
-			if(sizeof($va_projects)){
-				$output_rows = array();
-				$output_row = array("Project", "Report Date", "Specimen Number", "Taxon", "Element", "Media", "Derivatives", "Media public views", "Media view diversity", "Media view detail", "media downloads", "media download diversity", "media download detail");
-				$output_rows[] = join("\t", $output_row);
-				foreach($va_projects as $va_project){
-					$va_media_info = array();
-					$this->opo_project->load($va_project["project_id"]);
-					$va_project_specimens = array();
-					$q_project_media = $this->opo_project->getProjectMedia();
-					$va_project_media_ids = array();
-					$va_project_media_specimen_ids = array();
-					if($q_project_media->numRows()){
-							while($q_project_media->nextRow()){
-								if(in_array($q_project_media->get("specimen_id"), $va_filtered_specimen_ids)){ # --- don't show specimen filtered out in browser filter table
-									$va_project_media_ids[] = $q_project_media->get("media_id");
-									if($q_project_media->get("specimen_id")){
-										$va_project_media_specimen_ids[$q_project_media->get("media_id")] = $q_project_media->get("specimen_id");
-									}
-								}
-							}
-							if(is_array($va_project_media_specimen_ids) && sizeof($va_project_media_specimen_ids)){
-								$q_project_specimen_info = $o_db->query("select * from ms_specimens where specimen_id IN (".join(", ", $va_project_media_specimen_ids).")");
-								if($q_project_specimen_info->numRows()){
-									while($q_project_specimen_info->nextRow()){
-										$va_project_specimens[] = $q_project_specimen_info->getRow();
-									}
-								}
-							}
+ 		function downloadSummary() {
+ 			# essentially copy media cart md but for all media user has access to 
+ 			$va_projects = $this->opo_project->getProjectsForMember(
+				$this->request->user->get("user_id"));
+ 			$t_proj = new ms_projects();
+ 			$t_media = new ms_media();
+ 			$t_media_file = new ms_media_files();
+ 			$va_media_file_ids = [];
+ 			foreach ($va_projects as $va_proj) {
+ 				$t_proj->load($va_proj["project_id"]);
+ 				$qr_media = $t_proj->getProjectMedia(true);
+				while($qr_media->nextRow()){
+					$va_media_files = 
+						$t_media->getMediaFiles($qr_media->get("media_id"));
+					foreach ($va_media_files as $t_mf) {
+						$va_media_file_ids[] = $t_mf->get("media_file_id");
 					}
-					if(sizeof($va_project_specimens)){
-						# --- make array with specimen info
-						foreach($va_project_specimens as $va_project_specimen){
-							$va_specimen_info[$va_project_specimen["specimen_id"]] = array(
-									"specimen_number" => $this->opo_specimen->formatSpecimenNumber($va_project_specimen), 
-									"specimen_taxonomy" => $this->opo_specimen->getSpecimenTaxonomy($va_project_specimen["specimen_id"]),
-									"specimen_views" => $this->opo_specimen->numViews($va_project_specimen["specimen_id"]),
-									"num_specimen_media" => sizeof($va_specimen_media_ids),
-									"specimen_id" => $va_project_specimen["specimen_id"],
-									"element" => $va_project_specimen["element"]
-								);
+				}						
+ 			}
 
-						}
+ 			if(sizeof($va_media_file_ids)){
+ 				$vs_tmp_file_name = tempnam(caGetTempDirPath(), 'media_statistics');
+ 				$vs_text_file_name = "morphosourceUserMediaStatistics_".date('m_d_y_His');
+ 				$va_text_file_text = 
+ 					$t_media_file->mediaMdText($va_media_file_ids, null, True);
+ 				if(sizeof($va_text_file_text)){
+ 					$vo_file = fopen($vs_tmp_file_name, "w");
+					foreach($va_text_file_text as $va_row){
+						fputcsv($vo_file, $va_row);			
 					}
-					if(sizeof($va_project_media_ids)){
-						# --- make array with media info
-						if(sizeof($va_project_media_ids)){
-							# --- get all the elements in one query for use later
-							$q_elements = $o_db->query("SELECT element, media_id from ms_media where media_id IN (".join(", ", $va_project_media_ids).")");
-							$va_elements = array();
-							if($q_elements->numRows()){
-								while($q_elements->nextRow()){
-									$va_elements[$q_elements->get("media_id")] = $q_elements->get("element");
-								}
-							}
+					fclose($vo_file);
 
-							# --- get all the derivatives in one query
-							$q_derivatives = $o_db->query("SELECT media_id, derived_from_media_id from ms_media where derived_from_media_id IN (".join(", ", $va_project_media_ids).")");
-							$va_derivatives = array();
-							if($q_derivatives->numRows()){
-								while($q_derivatives->nextRow()){
-									$va_derivatives[$q_derivatives->get("derived_from_media_id")][] = $q_derivatives->get("media_id");
-								}
-							}
-							
-							$va_rows = array();
-							$q_media_views = $o_db->query("SELECT mvs.*, u.fname, u.lname, u.email, u.user_id 
-													FROM ms_media_view_stats mvs 
-													LEFT JOIN ca_users as u ON mvs.user_id = u.user_id
-													WHERE mvs.media_id IN (".join(", ", $va_project_media_ids).")");
-							if($q_media_views->numRows()){
-								while($q_media_views->nextRow()){
-									$va_rows[$q_media_views->get("media_id")]["views"][$q_media_views->get("view_id")] = array("date" => date("n/j/y G:i", $q_media_views->get("viewed_on")), "user_id" => $q_media_views->get("user_id"), "user_info" => date("n/j/y G:i", $q_media_views->get("viewed_on")).(($q_media_views->get("user_id")) ? ", ".$q_media_views->get("fname")." ".$q_media_views->get("lname").", ".$q_media_views->get("email") : ""));
-								}
-							}
-			
-							$q_media_downloads = $o_db->query("SELECT mds.*, u.fname, u.lname, u.email, u.user_id 
-													FROM ms_media_download_stats mds 
-													INNER JOIN ca_users as u ON mds.user_id = u.user_id
-													WHERE mds.media_id IN (".join(", ", $va_project_media_ids).")");
-							$va_downloads_by_file = array();
-							if($q_media_downloads->numRows()){
-								while($q_media_downloads->nextRow()){
-									$va_rows[$q_media_downloads->get("media_id")]["downloads"][$q_media_downloads->get("download_id")] = array("media_file_id" => $q_media_downloads->get("media_file_id"), "date" => date("n/j/y G:i", $q_media_downloads->get("downloaded_on")), "user_id" => $q_media_downloads->get("user_id"), "email" => $q_media_downloads->get("email"), "name" => trim($q_media_downloads->get("fname")." ".$q_media_downloads->get("lname")), "user_info" => date("n/j/y G:i", $q_media_downloads->get("downloaded_on")).", ".$q_media_downloads->get("fname")." ".$q_media_downloads->get("lname").", ".$q_media_downloads->get("email"));
-									$va_downloads_by_file[$q_media_downloads->get("media_id")][$q_media_downloads->get("media_file_id")][] = $q_media_downloads->get("user_id");
-								}
-							}
-							foreach($va_project_media_ids as $vn_media_id){
-								$va_media_info[$vn_media_id] = array(
-											"media_id" => $vn_media_id,
-											"project_name" => $va_project["name"], 
-											"specimen_number" => $va_specimen_info[$va_project_media_specimen_ids[$vn_media_id]]["specimen_number"], 
-											"specimen_taxonomy" => $va_specimen_info[$va_project_media_specimen_ids[$vn_media_id]]["specimen_taxonomy"],
-											"element" => $va_elements[$vn_media_id],
-											"specimen_id" => $va_project_specimen["specimen_id"],
-											"mediaDownloadsViews" => $va_rows[$vn_media_id],
-											"downloadByFile" => $va_downloads_by_file[$vn_media_id],
-											"derivatives" => (is_array($va_derivatives[$vn_media_id]) && sizeof($va_derivatives[$vn_media_id])) ? join(", ", $va_derivatives[$vn_media_id]) : ""
-								);
-							}
-						}
-					}
-					if(sizeof($va_media_info)){
-						foreach($va_media_info as $va_info){			
-							$va_row = array();
-							$va_media_views_download = $va_info["mediaDownloadsViews"];
-							$vs_media = "M".$va_info["media_id"];
-							$vn_media_id = $va_info["media_id"];
-							$vs_media_views = "";
-							$vs_media_downloads = "";
-							$vs_view_diversity = "";
-							$va_view_by_user = array();
-							$vs_download_diversity = "";
-							$va_download_by_user = array();
-							if(is_array($va_media_views_download["views"]) && sizeof($va_media_views_download["views"])){
-								$vs_media_views = sizeof($va_media_views_download["views"])." media view".((sizeof($va_media_views_download["views"]) == 1) ? "" : "s").": ";
-								$vn_anon = 0;
-								foreach($va_media_views_download["views"] as $vn_view_id => $va_view_info){
-									if($va_view_info["user_id"]){
-										$vs_media_views .= $va_view_info["user_info"]."; ";
-										$va_view_by_user[$va_view_info["user_id"]] = $va_view_info["user_id"];
-									}else{
-										$vn_anon++;
-									}
-								}
-								if(sizeof($va_view_by_user)){
-									$vs_view_diversity = sizeof($va_view_by_user);
-									if($vn_anon){
-										$vs_view_diversity .= "+";
-									}
-								}else{
-									$vs_view_diversity = "all anonymous";
-								}			
-								if($vn_anon){
-									$vs_media_views .= $vn_anon." anonymous view".(($vn_anon == 1) ? "" : "s");
-								}
-							}
-							$va_downloads_by_file = $va_info["downloadByFile"];
-							if(is_array($va_media_views_download["downloads"]) && sizeof($va_media_views_download["downloads"])){
-								$vs_media_downloads = sizeof($va_media_views_download["downloads"])." media download".((sizeof($va_media_views_download["downloads"]) == 1) ? "" : "s").": ";
-								foreach($va_info["downloadByFile"] as $vn_file_id => $va_file_download_info){
-									if($vn_file_id){
-										$vs_media_downloads .= "M".$vn_media_id."-".$vn_file_id.": ".sizeof($va_file_download_info)." downloads; ";
-									}
-								}
-								foreach($va_media_views_download["downloads"] as $vn_download_id => $va_download_info){
-									$vs_media_downloads .= (($va_download_info["media_file_id"]) ? "M".$vn_media_id."-".$va_download_info["media_file_id"].": " : "").$va_download_info["date"].", ".$va_download_info["name"].", (".$va_download_info["email"]."); ";
-									$va_download_by_user[$va_download_info["user_id"]] = $va_download_info["user_id"];
-								}
-								$vs_download_diversity = sizeof($va_download_by_user);
-							}
+					$o_zip = new ZipStream();
+					$o_zip->addFile($vs_tmp_file_name, $vs_text_file_name.".csv");
+
+					$this->view->setVar('zip_stream', $o_zip);
+					$this->view->setVar('version_download_name', $vs_text_file_name.".zip");
 					
-							# --- shorten media views and downloads text to not break Excel
-							if(mb_strlen($vs_media_views) > 31000){
-								$vs_media_views = mb_substr($vs_media_views, 0, 31000)."... This info has been shortened to work with Excel";
-							}
-							if(mb_strlen($vs_media_downloads) > 31000){
-								$vs_media_downloads = mb_substr($vs_media_downloads, 0, 31000)."... This info has been shortened to work with Excel";
-							}
-							$va_output_row = array($va_info["project_name"], date("n/j/y", time()), $va_info["specimen_number"], (is_array($va_info["specimen_taxonomy"])) ? join(", ", $va_info["specimen_taxonomy"]) : "", preg_replace("/\r|\n/", " ", $va_info["element"]), $vs_media, $va_info["derivatives"], sizeof($va_media_views_download["views"]), $vs_view_diversity,  $vs_media_views, sizeof($va_media_views_download["downloads"]), $vs_download_diversity, $vs_media_downloads);
-							$output_rows[] = join("\t", $va_output_row);
-									
-						}
-					}
-				}
-				header("Content-Disposition: attachment; filename=MorphoSourceMediaReport_".date("m-d-y").".txt");
-				header("Content-type: application/vnd.ms-excel");
-				
-				$this->response->addContent(join("\n", $output_rows), 'view');
-			}
-		}
- 		# -------------------------------------------------------
- 		 function downloadSpecimenSummary() {
- 		 	$va_filtered_specimen_ids = explode(",", $this->request->getParameter('specimen_ids', pString));
-			$va_specimen_info = array();
-			# --- get list of available projects for user
-			$va_projects = $this->opo_project->getProjectsForMember($this->request->user->get("user_id"));
-			$o_db = new Db();
-			if(sizeof($va_projects)){
-				foreach($va_projects as $va_project){
-					$this->opo_project->load($va_project["project_id"]);
-					$va_project_specimens = $this->opo_project->getProjectSpecimens();
-					if(sizeof($va_project_specimens)){
-						foreach($va_project_specimens as $va_project_specimen){
-							if(in_array($va_project_specimen["specimen_id"], $va_filtered_specimen_ids)){
-								# --- has this specimen already been added to the array for export?
-								if($va_specimen_info[$va_project_specimen["specimen_id"]]){
-									# --- just add the project name to what is already there so it lists all project the specimen appears in
-									$va_specimen_info[$va_project_specimen["specimen_id"]]["name"] = $va_specimen_info[$va_project_specimen["specimen_id"]]["name"]."; ".$va_project["name"];
-								}else{
-									$va_specimen_media_ids = $this->opo_specimen->getSpecimenMediaIDs($va_project_specimen["specimen_id"]);
-									$va_specimen_media_ids_published = $this->opo_specimen->getSpecimenMediaIDs($va_project_specimen["specimen_id"], array("published" => true));
-							
-									$vn_specimen_media_views = 0;
-									$vn_specimen_media_downloads = 0;
-									if(is_array($va_specimen_media_ids) && sizeof($va_specimen_media_ids)){
-										$q_media_views = $o_db->query("SELECT count(*) c FROM ms_media_view_stats WHERE media_id IN (".join(", ", $va_specimen_media_ids).")");
-										$q_media_views->nextRow();
-										$vn_specimen_media_views = $q_media_views->get("c");
-								
-										$q_media_viewers = $o_db->query("SELECT DISTINCT user_id FROM ms_media_view_stats WHERE user_id > 0 AND media_id IN (".join(", ", $va_specimen_media_ids).")");
-										$vn_specimen_media_viewers = $q_media_viewers->numRows()." registered users";
-								
-										$q_media_view_anon_users = $o_db->query("SELECT count(*) c FROM ms_media_view_stats WHERE user_id IS NULL AND media_id IN (".join(", ", $va_specimen_media_ids).")");
-										$q_media_view_anon_users->nextRow();
-										$vn_specimen_media_viewers .= ", ".$q_media_view_anon_users->get("c")." anonymous users";
-								
-										$q_media_downloads = $o_db->query("SELECT count(*) c FROM ms_media_download_stats WHERE media_id IN (".join(", ", $va_specimen_media_ids).")");
-										$q_media_downloads->nextRow();
-										$vn_specimen_media_downloads = $q_media_downloads->get("c");	
-								
-										$q_media_downloaders = $o_db->query("SELECT DISTINCT user_id FROM ms_media_download_stats WHERE media_id IN (".join(", ", $va_specimen_media_ids).")");
-										$vn_specimen_media_downloaders = $q_media_downloaders->numRows()." users";
-								
-										# --- how many projects do the media belong in
-										$q_media_projects = $o_db->query("SELECT DISTINCT project_id from ms_media WHERE media_id IN (".join(", ", $va_specimen_media_ids).")");							
-										$vn_media_projects = $q_media_projects->numRows();
-									}
-		// 							if(sizeof($va_specimen_media_ids)){
-		// 								$va_rows = array();
-		// 								$q_media_views = $o_db->query("SELECT mvs.*, u.fname, u.lname, u.email, u.user_id 
-		// 														FROM ms_media_view_stats mvs 
-		// 														LEFT JOIN ca_users as u ON mvs.user_id = u.user_id
-		// 														WHERE mvs.media_id IN (".join(", ", $va_specimen_media_ids).")");
-		// 								if($q_media_views->numRows()){
-		// 									while($q_media_views->nextRow()){
-		// 										$va_rows[$q_media_views->get("media_id")]["views"][$q_media_views->get("view_id")] = array("date" => date("n/j/y G:i", $q_media_views->get("viewed_on")), "user_id" => $q_media_views->get("user_id"), "user_info" => date("n/j/y G:i", $q_media_views->get("viewed_on")).(($q_media_views->get("user_id")) ? ", ".$q_media_views->get("fname")." ".$q_media_views->get("lname").", ".$q_media_views->get("email") : ""));
-		// 									}
-		// 								}
-		// 				
-		// 								$q_media_downloads = $o_db->query("SELECT mds.*, u.fname, u.lname, u.email, u.user_id 
-		// 														FROM ms_media_download_stats mds 
-		// 														INNER JOIN ca_users as u ON mds.user_id = u.user_id
-		// 														WHERE mds.media_id IN (".join(", ", $va_specimen_media_ids).")");
-		// 								$va_downloads_by_file = array();
-		// 								if($q_media_downloads->numRows()){
-		// 									while($q_media_downloads->nextRow()){
-		// 										$va_rows[$q_media_downloads->get("media_id")]["downloads"][$q_media_downloads->get("download_id")] = array("media_file_id" => $q_media_downloads->get("media_file_id"), "date" => date("n/j/y G:i", $q_media_downloads->get("downloaded_on")), "user_id" => $q_media_downloads->get("user_id"), "email" => $q_media_downloads->get("email"), "name" => trim($q_media_downloads->get("fname")." ".$q_media_downloads->get("lname")), "user_info" => date("n/j/y G:i", $q_media_downloads->get("downloaded_on")).", ".$q_media_downloads->get("fname")." ".$q_media_downloads->get("lname").", ".$q_media_downloads->get("email"));
-		// 										$va_downloads_by_file[$q_media_downloads->get("media_id")][$q_media_downloads->get("media_file_id")][] = $q_media_downloads->get("user_id");
-		// 									}
-		// 								}
-		// 							}
-									$va_specimen_info[$va_project_specimen["specimen_id"]] = array(
-													"project_name" => $va_project["name"], 
-													"specimen_number" => $this->opo_specimen->formatSpecimenNumber($va_project_specimen), 
-													"specimen_taxonomy" => $this->opo_specimen->getSpecimenTaxonomy($va_project_specimen["specimen_id"]),
-													"specimen_description" => preg_replace("/\r|\n/", " ", $va_project_specimen["description"]),
-													"specimen_views" => $this->opo_specimen->numViews($va_project_specimen["specimen_id"]),
-													"num_specimen_media" => sizeof($va_specimen_media_ids),
-													"num_specimen_media_unpublished" => sizeof($va_specimen_media_ids) - sizeof($va_specimen_media_ids_published),
-													"specimen_media_views" => $vn_specimen_media_views,
-													"specimen_media_downloads" => $vn_specimen_media_downloads,
-													"specimen_id" => $va_project_specimen["specimen_id"],
-													"media_projects" => $vn_media_projects,
-													"specimen_media_viewers" => $vn_specimen_media_viewers,
-													"specimen_media_downloaders" => $vn_specimen_media_downloaders
-													#"mediaDownloadsViews" => $va_rows,
-													#"downloadByFile" => $va_downloads_by_file,
-												);
-								}
-							}
-						}
-					}
-				}
-			}
-			if(sizeof($va_specimen_info)){
- 				header("Content-Disposition: attachment; filename=MorphoSourceSpecimenReport_".date("m-d-y").".txt");
-				header("Content-type: application/vnd.ms-excel");
-				$va_rows = array();
-				$va_row = array("Specimen", "Taxon", "Description", "Specimen media", "Specimen projects", "Specimen views", "Specimen media views", "diversity", "Specimen media downloads", "diversity");
-				$va_rows[] = join("\t", $va_row);
-				$vs_display_project = "";
-				foreach($va_specimen_info as $va_info){					
-					$va_row = array($va_info["specimen_number"], join("; ", $va_info["specimen_taxonomy"]), $va_info["specimen_description"], $va_info["num_specimen_media"].(($va_info["num_specimen_media_unpublished"]) ? ", (".$va_info["num_specimen_media_unpublished"]." unpublished)" : ""), $va_info["media_projects"], $va_info["specimen_views"], $va_info["specimen_media_views"], $va_info["specimen_media_viewers"], $va_info["specimen_media_downloads"], $va_info["specimen_media_downloaders"]);
-					$va_rows[] = join("\t", $va_row);									
-				}
-			}
-			$this->response->addContent(join("\n", $va_rows), 'view');
+					$this->response->sendHeaders();
+					$vn_rc = $this->render('Detail/media_download_binary.php');
+					$this->response->sendContent();
+						
+					@unlink($vs_tmp_file_name);
 
+					return $vn_rc;
+ 				}
+ 			}
+ 		}
+ 		# -------------------------------------------------------
+ 		function downloadSpecimenSummary() {
+ 			$va_projects = $this->opo_project->getProjectsForMember(
+				$this->request->user->get("user_id"));
+ 			$t_proj = new ms_projects();
+ 			$t_media = new ms_media();
+ 			$t_media_file = new ms_media_files();
+ 			$t_specimen = new ms_specimens();
+ 			$va_media_file_ids = [];
+ 			foreach ($va_projects as $va_proj) {
+ 				$t_proj->load($va_proj["project_id"]);
+ 				$va_specimens = $t_proj->getProjectSpecimens();
+ 				foreach ($va_specimens as $vn_specimen_id => $va_spec) {
+ 					$va_media_ids = $t_specimen->getSpecimenMediaIDs(
+ 						$vn_specimen_id, 
+ 						[
+ 							'published' => true, 
+ 							'user_id' => $this->request->user->get("user_id")
+ 						]
+ 					);
+ 					foreach ($va_media_ids as $vn_media_id) {
+ 						$va_media_files = $t_media->getMediaFiles($vn_media_id);
+ 						foreach ($va_media_files as $t_mf) {
+ 							$va_media_file_ids[] = $t_mf->get("media_file_id");
+ 						}
+ 					}
+ 				}
+ 			}
+
+ 			if(sizeof($va_media_file_ids)){
+ 				$vs_tmp_file_name = tempnam(caGetTempDirPath(), 'specimen_statistics');
+ 				$vs_text_file_name = "morphosourceUserSpecimenMediaStatistics_".date('m_d_y_His');
+ 				$va_text_file_text = 
+ 					$t_media_file->mediaMdText($va_media_file_ids, null, True);
+ 				if(sizeof($va_text_file_text)){
+ 					$vo_file = fopen($vs_tmp_file_name, "w");
+					foreach($va_text_file_text as $va_row){
+						fputcsv($vo_file, $va_row);			
+					}
+					fclose($vo_file);
+
+					$o_zip = new ZipStream();
+					$o_zip->addFile($vs_tmp_file_name, $vs_text_file_name.".csv");
+
+					$this->view->setVar('zip_stream', $o_zip);
+					$this->view->setVar('version_download_name', $vs_text_file_name.".zip");
+					
+					$this->response->sendHeaders();
+					$vn_rc = $this->render('Detail/media_download_binary.php');
+					$this->response->sendContent();
+						
+					@unlink($vs_tmp_file_name);
+
+					return $vn_rc;
+ 				}
+ 			}
  		}
  		# ------------------------------------------------------- 		
  	}

--- a/app/models/ms_media.php
+++ b/app/models/ms_media.php
@@ -831,18 +831,23 @@ class ms_media extends BaseModel {
  		return $va_file_info;
  	}
  	# ------------------------------------------------------
- 	public function getMediaFiles($pn_media_id=null){
+ 	public function getMediaFiles($pn_media_id=null, $pb_published=False){
  		if(!($vn_media_id = $pn_media_id)) { 
  			if (!($vn_media_id = $this->getPrimaryKey())) {
  				return null; 
  			}
  		}
  		
+ 		$vs_pub_where = " AND (mf.published > 0 OR (mf.published IS NULL AND m.published > 0))";
+
  		$va_media_files = array();
  		# Get media files
  		$o_db= $this->getDb();
- 		$q_result = $o_db->query("SELECT media_file_id FROM ms_media_files ".
- 			"WHERE media_id = ?", $vn_media_id);
+ 		$q_result = $o_db->query("
+ 			SELECT mf.media_file_id 
+ 			FROM ms_media_files AS mf
+ 			LEFT JOIN ms_media AS m ON m.media_id = mf.media_id
+ 			WHERE mf.media_id = ?".($pb_published ? $vs_pub_where : ""), $vn_media_id);
 
  		if($q_result->numRows()){
  			while($q_result->nextRow()){

--- a/app/models/ms_media_files.php
+++ b/app/models/ms_media_files.php
@@ -31,7 +31,9 @@
  */
  
 require_once(__CA_LIB_DIR__."/core/BaseModel.php");
+require_once(__CA_MODELS_DIR__."/ca_users.php");
 require_once(__CA_MODELS_DIR__."/ms_projects.php");
+require_once(__CA_MODELS_DIR__."/ms_media_download_stats.php");
 require_once(__CA_MODELS_DIR__."/ms_media_files_multifiles.php");
 require_once(__CA_LIB_DIR__.'/ms/ARK.php');
 require_once(__CA_LIB_DIR__.'/ms/DOI.php');
@@ -565,7 +567,7 @@ class ms_media_files extends BaseModel {
 	*  $pa_media_file_ids = array of media file ids to get MD for
 	*  $t_specimen = ms_specimens object
 	*/
-	public function mediaMdText($pa_media_file_ids, $t_specimen = null) {
+	public function mediaMdText($pa_media_file_ids, $t_specimen = null, $dl_usage = False) {
 		if(sizeof($pa_media_file_ids)){
 			$o_db = $this->getDb();
 			if(!$t_specimen){
@@ -574,13 +576,14 @@ class ms_media_files extends BaseModel {
 			$t_media = new ms_media();
 			$t_media_file = new ms_media_files();
 			$q_media_files = $o_db->query("
-				SELECT mf.media_file_id, mf.title file_title, mf.notes file_notes, mf.side file_side, mf.element file_element, mf.media file_media, mf.doi, mf.ark, mf.file_type, m.*, f.name facility, i.name institution, s.locality_description, s.relative_age, s.absolute_age, scan.name scanner
+				SELECT mf.media_file_id, mf.title file_title, mf.notes file_notes, mf.side file_side, mf.element file_element, mf.media file_media, mf.doi, mf.ark, mf.file_type, m.*, f.name facility, i.name institution, s.locality_description, s.relative_age, s.absolute_age, scan.name scanner, p.name project_name
 				FROM ms_media_files mf 
 				INNER JOIN ms_media as m ON mf.media_id = m.media_id
 				LEFT JOIN ms_specimens as s ON m.specimen_id = s.specimen_id
 				LEFT JOIN ms_facilities as f ON f.facility_id = m.facility_id
 				LEFT JOIN ms_institutions as i ON s.institution_id = i.institution_id
 				LEFT JOIN ms_scanners as scan ON scan.scanner_id = m.scanner_id
+				LEFT JOIN ms_projects as p ON m.project_id = p.project_id
 				WHERE mf.media_file_id IN (".join(", ", $pa_media_file_ids).")");
 			$va_all_md = array();
 			if($q_media_files->numRows()){
@@ -592,6 +595,7 @@ class ms_media_files extends BaseModel {
 									"public url",
 									"doi",
 									"ark",
+									"project",
 									"raw or derivative",
 									"mime type",
 									"file size",
@@ -633,6 +637,57 @@ class ms_media_files extends BaseModel {
 									"citation instruction statement (to be copy-pasted into acknolwedgements)"
 								);
 
+				if($dl_usage){
+					$va_header = array_merge($va_header, 
+						array(
+							"media group views",
+							"number of download statistics for this media",
+							"total_downloads",
+							"dl_intended_use_School",
+							"dl_intended_use_School_K_6",
+							"dl_intended_use_School_7_12",
+							"dl_intended_use_School_College_Post_Secondary",
+							"dl_intended_use_School_Graduate_school",
+							"dl_intended_use_Education",
+							"dl_intended_use_Education_K_6",
+							"dl_intended_use_Education_7_12",
+							"dl_intended_use_Education_College_Post_Secondary",
+							"dl_intended_use_Educaton_general",
+							"dl_intended_use_Education_museums_public_outreach",
+							"dl_intended_use_Personal_interest",
+							"dl_intended_use_Research",
+							"dl_intended_use_Commercial",
+							"dl_intended_use_Art",
+							"dl_intended_use_other",
+							"dl_intended_use_3d_print",
+							"demographic statistics of users downloading this media",
+							"total_download_users",
+							"u_affiliation_Student",
+							"u_affiliation_Student:_K-6",
+							"u_affiliation_Student:7-12",
+							"u_affiliation_Student:_College/Post-Secondary",
+							"u_affiliation_Student:_Graduate",
+							"u_affiliation_Faculty",
+							"u_affiliation_Faculty:_K-6",
+							"u_affiliation_Faculty:7-12",
+							"u_affiliation_Faculty_College/Post-Secondary",
+							"u_affiliation_Staff:_College/Post-Secondary",
+							"u_affiliation_General_Educator",
+							"u_affiliation_Museum",
+							"u_affiliation_Museum_Curator",
+							"u_affiliation_Museum_Staff",
+							"u_affiliation_Librarian",
+							"u_affiliation_IT",
+							"u_affiliation_Private_Individual",
+							"u_affiliation_Researcher",
+							"u_affiliation_Private_Industry",
+							"u_affiliation_Artist",
+							"u_affiliation_Government",
+							"u_affiliation_other"
+						)
+					);
+				}
+
 				$va_all_md[] = $va_header;
 				while($q_media_files->nextRow()){
 					$va_media_md = array();
@@ -664,6 +719,7 @@ class ms_media_files extends BaseModel {
 					
 					$va_media_md[] = $q_media_files->get('doi');
 					$va_media_md[] = $q_media_files->get('ark');
+					$va_media_md[] = $q_media_files->get('project_name');
 
 					$va_media_md[] = $t_media_file->getChoiceListValue("file_type", $q_media_files->get("file_type"));
 					$va_media_md[] = $va_original_properties['MIMETYPE'];
@@ -727,12 +783,89 @@ class ms_media_files extends BaseModel {
 					$va_media_md[] = $q_media_files->get("grant_support");
 					$va_media_md[] = $q_media_files->get("copyright_info");
 					$va_media_md[] = $t_media->getChoiceListValue("copyright_license", $q_media_files->get("copyright_license"));
+
 					if($q_media_files->get("media_citation_instruction1")){
 						$va_media_md[] = "Citation: ".$t_media->getMediaCitationInstructionsFromFields(array("media_citation_instruction1" => $q_media_files->get("media_citation_instruction1"), "media_citation_instruction2" => $q_media_files->get("media_citation_instruction2"), "media_citation_instruction3" => $q_media_files->get("media_citation_instruction3")));
 					}else{
 						$va_media_md[] = "";
 					}
+
+					if($dl_usage){
+						### Media group views ###
+						$o_db = $this->getDb();
+						$q_view_num = $o_db->query("
+							SELECT count(*) AS c
+							FROM ms_media_files AS mf
+							LEFT JOIN ms_media AS m ON m.media_id = mf.media_id
+							LEFT JOIN ms_media_view_stats AS ms ON ms.media_id = m.media_id
+							WHERE mf.media_file_id = ".$q_media_files->get("media_file_id")	
+						);
+
+						$vn_view_num = 0;
+						if($q_view_num->numRows()){
+	 						while($q_view_num->nextRow()){
+	 							$vn_view_num = $q_view_num->get("c");
+	 						}
+	 					}
+
+ 						$va_media_md[] = $vn_view_num;
+
+						### Download statistics ###
+						$va_dl_stats = $this->getIntendedUse(
+							$q_media_files->get('media_file_id'));
+
+						$va_media_md[] = ""; # Section header column
+						$va_media_md[] = $va_dl_stats["Total_Downloads"];
+						$va_media_md[] = $va_dl_stats["School"];
+						$va_media_md[] = $va_dl_stats["School_K_6"];
+						$va_media_md[] = $va_dl_stats["School_7_12"];
+						$va_media_md[] = $va_dl_stats["School_College_Post_Secondary"];
+						$va_media_md[] = $va_dl_stats["School_Graduate_school"];
+						$va_media_md[] = $va_dl_stats["Education"];
+						$va_media_md[] = $va_dl_stats["Education_K_6"];
+						$va_media_md[] = $va_dl_stats["Education_7_12"];
+						$va_media_md[] = $va_dl_stats["Education_College_Post_Secondary"];
+						$va_media_md[] = $va_dl_stats["Education_general"];
+						$va_media_md[] = $va_dl_stats["Education_museums_public_outreach"];
+						$va_media_md[] = $va_dl_stats["Personal_interest"];
+						$va_media_md[] = $va_dl_stats["Research"];
+						$va_media_md[] = $va_dl_stats["Commercial"];
+						$va_media_md[] = $va_dl_stats["Art"];
+						$va_media_md[] = $va_dl_stats["other"];
+						$va_media_md[] = $va_dl_stats["3d_print"];
+
+						### Downloading user demographic statistics ###
+
+						$va_dl_user_stats = $this->getDLUserStatistics(
+							$q_media_files->get('media_file_id'));
+
+						$va_media_md[] = ""; # Section header column
+						$va_media_md[] = $va_dl_user_stats["Total_Download_Users"];
+						$va_media_md[] = $va_dl_user_stats["Student"];
+						$va_media_md[] = $va_dl_user_stats["Student:_K-6"];
+						$va_media_md[] = $va_dl_user_stats["Student:7-12"];
+						$va_media_md[] = $va_dl_user_stats["Student:_College/Post-Secondary"];
+						$va_media_md[] = $va_dl_user_stats["Student:_Graduate"];
+						$va_media_md[] = $va_dl_user_stats["Faculty"];
+						$va_media_md[] = $va_dl_user_stats["Faculty:_K-6"];
+						$va_media_md[] = $va_dl_user_stats["Faculty:7-12"];
+						$va_media_md[] = $va_dl_user_stats["Faculty_College/Post-Secondary"];
+						$va_media_md[] = $va_dl_user_stats["Staff:_College/Post-Secondary"];
+						$va_media_md[] = $va_dl_user_stats["General_Educator"];
+						$va_media_md[] = $va_dl_user_stats["Museum"];
+						$va_media_md[] = $va_dl_user_stats["Museum_Curator"];
+						$va_media_md[] = $va_dl_user_stats["Museum_Staff"];
+						$va_media_md[] = $va_dl_user_stats["Librarian"];
+						$va_media_md[] = $va_dl_user_stats["IT"];
+						$va_media_md[] = $va_dl_user_stats["Private_Individual"];
+						$va_media_md[] = $va_dl_user_stats["Researcher"];
+						$va_media_md[] = $va_dl_user_stats["Private_Industry"];
+						$va_media_md[] = $va_dl_user_stats["Artist"];
+						$va_media_md[] = $va_dl_user_stats["Government"];
+						$va_media_md[] = $va_dl_user_stats["other"];
+					}
 					
+
 					#$va_all_md[] = join(",", $va_media_md);
 					$va_all_md[] = $va_media_md;
 				}
@@ -1116,5 +1249,163 @@ class ms_media_files extends BaseModel {
 			$va_ark["error"] = "Could not delete ARK for media: ".$e->getMessage();
 		}
 		return $va_ark;
+ 	}
+ 	# ------------------------------------------------------
+ 	# Media file download statistics
+ 	# ------------------------------------------------------
+ 	/*
+ 	 *
+ 	 */
+ 	private function getIntendedUse($pn_media_file_id=null) {
+ 		if(!($vn_media_file_id = $pn_media_file_id)) { 
+ 			if (!($vn_media_file_id = $this->getPrimaryKey())) {
+ 				return null; 
+ 			}
+ 		}
+
+ 		$va_dl_stats = [
+ 			"Total_Downloads" => 0,
+ 			"School" => 0,
+ 			"School_K_6" => 0,
+ 			"School_7_12" => 0,
+ 			"School_College_Post_Secondary" => 0,
+ 			"School_Graduate_school" => 0,
+ 			"Education" => 0,
+ 			"Education_K_6" => 0,
+ 			"Education_7_12" => 0,
+ 			"Education_College_Post_Secondary" => 0,
+ 			"Education_general" => 0,
+ 			"Education_museums_public_outreach" => 0,
+ 			"Personal_interest" => 0,
+ 			"Research" => 0,
+ 			"Commercial" => 0,
+ 			"Art" => 0,
+ 			"other" => 0,
+ 			"3d_print" => 0
+ 		];
+
+ 		$o_db = $this->getDb();
+ 		$q_media_file_dl = $o_db->query("
+ 			SELECT *
+ 			FROM ms_media_download_stats
+ 			WHERE media_file_id = ".$vn_media_file_id."
+ 			");
+
+ 		$t_dl = new ms_media_download_stats();
+ 		if($q_media_file_dl->numRows()){
+ 			while($q_media_file_dl->nextRow()){
+ 				$t_dl->load($q_media_file_dl->get("download_id"));
+
+ 				$va_dl_stats["Total_Downloads"]++;
+ 				if($t_dl->get("intended_use_other")){
+ 					$va_dl_stats["other"]++;
+ 				}
+ 				if($t_dl->get("3d_print")){
+ 					$va_dl_stats["3d_print"]++;
+ 				}
+ 				if(($va_intended_use = $t_dl->get("intended_use"))
+ 					&& is_array($va_intended_use)
+ 					&& sizeof($va_intended_use)
+ 				){
+ 					 # todo remove this
+ 					foreach($va_intended_use as $vs_use){
+ 						$va_dl_stats[$vs_use]++;
+ 					}
+ 				}
+ 			}
+ 		}
+
+ 		$va_dl_stats["School"] = $va_dl_stats["School_K_6"] + 
+ 			$va_dl_stats["School_7_12"] + 
+ 			$va_dl_stats["School_College_Post_Secondary"] + 
+ 			$va_dl_stats["School_Graduate_school"];
+ 		$va_dl_stats["Education"] = $va_dl_stats["Education_K_6"] + 
+ 			$va_dl_stats["Education_7_12"] + 
+ 			$va_dl_stats["Education_College_Post_Secondary"] + 
+ 			$va_dl_stats["Education_general"] + 
+ 			$va_dl_stats["Education_museums_public_outreach"];
+
+ 		return $va_dl_stats;
+ 	}
+ 	/*
+ 	 *
+ 	 */
+ 	private function getDLUserStatistics($pn_media_file_id=null) {
+ 		if(!($vn_media_file_id = $pn_media_file_id)) { 
+ 			if (!($vn_media_file_id = $this->getPrimaryKey())) {
+ 				return null; 
+ 			}
+ 		}
+
+ 		$va_dl_user_stats = [
+ 			"Total_Download_Users" => 0,
+ 			"Student" => 0,
+ 			"Student:_K-6" => 0,
+ 			"Student:7-12" => 0,
+ 			"Student:_College/Post-Secondary" => 0,
+ 			"Student:_Graduate" => 0,
+ 			"Faculty" => 0,
+ 			"Faculty:_K-6" => 0,
+ 			"Faculty:7-12" => 0,
+ 			"Faculty_College/Post-Secondary" => 0,
+ 			"Staff:_College/Post-Secondary" => 0,
+ 			"General_Educator" => 0,
+ 			"Museum" => 0,
+ 			"Museum_Curator" => 0,
+ 			"Museum_Staff" => 0,
+ 			"Librarian" => 0,
+ 			"IT" => 0,
+ 			"Private_Individual" => 0,
+ 			"Researcher" => 0,
+ 			"Private_Industry" => 0,
+ 			"Artist" => 0,
+ 			"Government" => 0,
+ 			"other" => 0,
+ 		];
+
+ 		$o_db = $this->getDb();
+ 		$q_dl_users = $o_db->query("
+ 			SELECT user_id
+ 			FROM ca_users
+ 			WHERE user_id IN (
+ 				SELECT DISTINCT(user_id)
+ 				FROM ms_media_download_stats
+ 				WHERE media_file_id = ".$vn_media_file_id."
+ 			)
+ 		");
+
+ 		if($q_dl_users->numRows()){
+ 			$t_user = new ca_users();
+ 			while($q_dl_users->nextRow()){
+ 				$t_user->load($q_dl_users->get("user_id"));
+ 				
+ 				$va_dl_user_stats["Total_Download_Users"]++;
+ 				
+ 				if($t_user->getPreference("user_profile_professional_affiliation_other")){
+ 					$va_dl_user_stats["other"]++;
+ 				}
+ 				
+ 				if(($va_affil = $t_user->getPreference("user_profile_professional_affiliation"))
+ 					&& is_array($va_affil)
+ 					&& sizeof($va_affil)
+ 				){
+ 					foreach ($va_affil as $vs_affil) {
+ 						$va_dl_user_stats[str_replace(" ", "_", $vs_affil)]++;
+ 					}
+ 				}
+ 			}
+ 		}
+
+ 		$va_dl_user_stats["Student"] = $va_dl_user_stats["Student:_K-6"] + 
+ 			$va_dl_user_stats["Student:7-12"] + 
+ 			$va_dl_user_stats["Student:_College/Post-Secondary"] + 
+ 			$va_dl_user_stats["Student:_Graduate"];
+ 		$va_dl_user_stats["Faculty"] = $va_dl_user_stats["Faculty:_K-6"] + 
+ 			$va_dl_user_stats["Faculty:7-12"] + 
+ 			$va_dl_user_stats["Faculty_College/Post-Secondary"];
+ 		$va_dl_user_stats["Museum"] = $va_dl_user_stats["Museum_Curator"] + 
+ 			$va_dl_user_stats["Museum_Staff"];
+
+ 		return $va_dl_user_stats;
  	}
 }

--- a/themes/morphosource/css/morphosource.css
+++ b/themes/morphosource/css/morphosource.css
@@ -1572,7 +1572,7 @@ div.msMediaDownloadRequestFormHelpText {
 }
 
 #msMediaDownloadRequestDashboardContainer, #msMediaMovementRequestDashboardContainer{
-	padding-top:20px;
+	padding-top:10px;
 	max-height:300px;
 	overflow:auto;
 }

--- a/themes/morphosource/views/Detail/media_download_binary.php
+++ b/themes/morphosource/views/Detail/media_download_binary.php
@@ -26,7 +26,7 @@
  * ----------------------------------------------------------------------
  */
 	//$vs_file_path = $this->getVar('version_path');
-	
+
 	header("Content-type: application/octet-stream");
 	header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
 	header("Cache-Control: no-store, no-cache, must-revalidate");

--- a/themes/morphosource/views/Detail/ms_project_detail_html.php
+++ b/themes/morphosource/views/Detail/ms_project_detail_html.php
@@ -44,10 +44,25 @@
 </H1>
 <div id="projectDetail">
 	<div class="tealRule"><!-- empty --></div>
+	<div class='InfoContainerRight'>
 <?php
 	if($vs_project_abstract){
-		print "<div class='InfoContainerRight'><H2>"._t("About the project")."</H2><div class='unit'>".$vs_project_abstract."</div></div>";
+		print "<H2>"._t("About the project")."</H2><div class='unit'>".$vs_project_abstract."</div>";
 	}
+
+	print "<H2>Metadata and usage reports</H2>";
+	print "<div class='unit'>";
+	print "<div>";
+	print "<div style='margin-bottom: 10px; margin-top: 5px;'>".caNavLink($this->request, "<i class='fa fa-download'></i> Project media", "button buttonMedium", "Detail", "ProjectDetail", "exportMediaReport", ["project_id" => $vn_project_id]);
+	print "<span style='margin-left:10px;'></span>";
+	print caNavLink($this->request, "<i class='fa fa-download'></i> All media of project specimens", "button buttonMedium", "Detail", "ProjectDetail", "exportSpecimenMediaReport", ["project_id" => $vn_project_id]);
+	print "</div>";
+	print "<p style='margin-top: 0px; margin-left: 0px;'><i>Warning: For large projects, this may take up to several minutes</i></p>";
+	print "</div>";
+	print "</div>";
+?>
+	</div>
+<?php
 	print "<div class='InfoContainerLeft'>";
 	print "<H2>"._t("Members")."</H2><div class='unit'>";
 

--- a/themes/morphosource/views/MyProjects/Dashboard/dashboard_html.php
+++ b/themes/morphosource/views/MyProjects/Dashboard/dashboard_html.php
@@ -34,6 +34,17 @@
 
 ?>
 <div id="dashboardColLeft">
+	<div class="dashboardButtons" style="margin: 15px 0px 15px 0px">
+	<?php
+		if($this->request->user->canDoAction("is_administrator") || ($this->request->user->get("user_id") == $t_project->get("user_id"))){
+			print "&nbsp;".caNavLink($this->request, _t("Project Settings"), "button buttonMedium", "MyProjects", "Project", "form", array("project_id" => $t_project->get("project_id")));
+			print "&nbsp;".caNavLink($this->request, _t("Manage Members"), "button buttonMedium", "MyProjects", "Members", "listForm");
+		}
+		if($this->request->user->canDoAction('batch_upload_enabled')){
+			print "&nbsp;".caNavLink($this->request, _t("Batch Import"), "button buttonMedium", "MyProjects", "BatchImport", "overview");
+		}
+	?>
+	</div>
 	<div class="blueRule"><!-- empty --></div>
 	<H1>
 		<?php print $t_project->get("name"); ?>
@@ -56,28 +67,26 @@
 		}
 		if($t_project->get("publication_status")){
 			print "<div id='projectLink' style='display:none;'>".caNavUrl($this->request, "Detail", "ProjectDetail", "Show", array("project_id" => $t_project->get("project_id")))."</div>";
-			print "<br/><br/><b>"._t("Your project is public.")."</b><br/>".caNavLink($this->request, _t("View public page"), "publicProjectLink", "Detail", "ProjectDetail", "Show", array("project_id" => $t_project->get("project_id")))." or <a href='#' onClick='copyToClipboard(\"#projectLink\"); return false;' class='button buttonSmall' title='click to copy link to clipboard'>Copy <i class='fa fa-external-link'></i></a><br/>";
+			print "<br/><br/><b>"._t("Your project is public.")."</b><br/>".caNavLink($this->request, _t("View public page"), "publicProjectLink", "Detail", "ProjectDetail", "Show", array("project_id" => $t_project->get("project_id")))." or <a href='#' onClick='copyToClipboard(\"#projectLink\"); return false;' title='click to copy link to clipboard'>copy to clipboard <i class='fa fa-clipboard'></i></a><br/>";
 		}else{
 			print "<br/><br/><b>"._t("Your project is private.")."</b>";
 		}
 ?>
 	</div><!-- end dashboardAbstract -->
-	<div class="dashboardButtons" style="text-align:center;">
+
+<div class="tealRule"></div>
+<div>
+	<h2 style="padding-bottom: 2px;">Metadata and usage reports</h2>
+	<div style="margin-top: 10px; margin-left: 5px;">
 <?php
-	print caNavLink($this->request, _t("New Project"), "button buttonSmall", "MyProjects", "Project", "form", array("new_project" => 1));
-	if($this->request->user->canDoAction("is_administrator") || ($this->request->user->get("user_id") == $t_project->get("user_id"))){
-		print "&nbsp;".caNavLink($this->request, _t("Project Info"), "button buttonSmall", "MyProjects", "Project", "form", array("project_id" => $t_project->get("project_id")));
-		print "&nbsp;".caNavLink($this->request, _t("Manage Members"), "button buttonSmall", "MyProjects", "Members", "listForm");
-	}
-	if($this->getVar("num_projects") > 1){
-		print "&nbsp;".caNavLink($this->request, _t("Change Project"), "button buttonSmall", "MyProjects", "Dashboard", "projectList");
-	}
-	if($this->request->user->canDoAction('batch_upload_enabled')){
-	#if(in_array($this->request->user->get("user_id"), array(866, 1589, 12, 162, 10, 11, 13, 7, 37, 2348, 4346, 4450, 4253, 4864, 3298))){
-		print "&nbsp;".caNavLink($this->request, _t("Batch Import"), "button buttonSmall", "MyProjects", "BatchImport", "overview");
-	}
+	print caNavLink($this->request, "<i class='fa fa-download'></i> Project media", "button buttonSmall", "MyProjects", "Dashboard", "exportMediaReport");
+	print "<span style='margin-left:10px;'></span>";
+	print caNavLink($this->request, "<i class='fa fa-download'></i> All media of project specimens", "button buttonSmall", "MyProjects", "Dashboard", "exportSpecimenMediaReport");
 ?>
 	</div>
+	<p style='margin-top: 10px; margin-left:5px;'><i>Warning: For large projects, this may take up to several minutes</i><p>
+</div>
+
 <?php
 	print $this->render('Dashboard/pending_download_requests_html.php');
 	print $this->render('Dashboard/media_movement_requests_html.php');	

--- a/themes/morphosource/views/Stats/specimen_info_html.php
+++ b/themes/morphosource/views/Stats/specimen_info_html.php
@@ -33,10 +33,12 @@ $va_media_projects = $this->getVar('media_projects');
 if (sizeof($va_specimen_info)) {	
 	print "<br/><div class='blueRule'><!-- empty --></div>";
 	print "<H1>Specimen Info</H1>";
-	print "<H2>".$va_specimen_info["specimen_name"].", Specimen Public Views: ".$va_specimen_info["specimen_views"].", ";
-	print "Specimen Media: ".$va_specimen_info["num_specimen_media"]."</H2>";
+	print "<H2>".$va_specimen_info["specimen_name"]."</H2>";
+	print "<H2>".$va_specimen_info["num_specimen_media"]." Media Groups".($va_specimen_info["num_specimen_media_unpublished"] ? " (".$va_specimen_info["num_specimen_media_unpublished"]." unpublished)" : "")."</H2>";
+	print "<H2>".$va_specimen_info["specimen_views"]." specimen views</H2>";
+
 	if($va_specimen_info["num_specimen_media_no_access"] > 0){
-		print "<H2><b>*** ".$va_specimen_info["num_specimen_media_no_access"]." unpublished specimen media belong to projects you are not a member of</b></H2>";
+		print "<H2><b>*** ".$va_specimen_info["num_specimen_media_no_access"]." unpublished specimen media in projects you do not have membership in</b></H2>";
 	}
 	if (sizeof($va_rows)) {
 ?>
@@ -59,10 +61,10 @@ if (sizeof($va_specimen_info)) {
 					<?php print _t('Media'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Media Public Views'); ?>
+					<?php print _t('Media Views (Click for detail)'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Media Downloads'); ?>
+					<?php print _t('Media Downloads (Click for detail)'); ?>
 				</th>
 			</tr>
 		</thead>
@@ -84,12 +86,12 @@ if (sizeof($va_specimen_info)) {
 				<td>
 <?php
 					if(is_array($va_row["views"]) && sizeof($va_row["views"])){
-						print "<a href='#' onClick='$(\"#views".$vn_media_id."\").slideToggle(); return false;'><b>".sizeof($va_row["views"])." media view".((sizeof($va_row["views"]) == 1) ? "" : "s")."</b></a><br/>";
+						print "<a href='#' onClick='$(\"#views".$vn_media_id."\").slideToggle(); return false;'><b>".sizeof($va_row["views"])."</b></a><br/>";
 						print "<div id='views".$vn_media_id."' style='display:none;'>";
 						$vn_anon = 0;
 						foreach($va_row["views"] as $vn_view_id => $va_view_info){
 							if($va_view_info["user_id"]){
-								print $va_view_info["user_info"]."; ";
+								print "<p>".$va_view_info["user_info"]."</p>";
 							}else{
 								$vn_anon++;
 							}
@@ -107,16 +109,11 @@ if (sizeof($va_specimen_info)) {
 				<td>
 <?php
 					if(is_array($va_row["downloads"]) && sizeof($va_row["downloads"])){
-						print "<a href='#' onClick='$(\"#downloads".$vn_media_id."\").slideToggle(); return false;'><b>".sizeof($va_row["downloads"])." media download".((sizeof($va_row["downloads"]) == 1) ? "" : "s")."</b><br/>";
-						foreach($va_downloads_by_file[$vn_media_id] as $vn_file_id => $va_file_download_info){
-							if($vn_file_id){
-								print "M".$vn_media_id."-".$vn_file_id.": ".sizeof($va_file_download_info)." downloads; ";
-							}
-						}
+						print "<a href='#' onClick='$(\"#downloads".$vn_media_id."\").slideToggle(); return false;'><b>".sizeof($va_row["downloads"])."</b><br/>";
 						print "</a><br/>";
 						print "<div id='downloads".$vn_media_id."' style='display:none;'>";
 						foreach($va_row["downloads"] as $vn_download_id => $va_download_info){
-							print (($va_download_info["media_file_id"]) ? "<b>M".$vn_media_id."-".$va_download_info["media_file_id"]."</b>: " : "").$va_download_info["date"].", <a href='#' onClick='jQuery(\"#specimenInfo\").load(\"".caNavUrl($this->request, "", "Stats", "userInfo", array('user_id' => $va_download_info["user_id"]))."\"); return false;'>".$va_download_info["name"]."</a>, (".$va_download_info["email"]."); ";
+							print "<p>".(($va_download_info["media_file_id"]) ? "<b>M".$vn_media_id."-".$va_download_info["media_file_id"]."</b>: " : "").$va_download_info["date"].", <a href='#' onClick='jQuery(\"#specimenInfo\").load(\"".caNavUrl($this->request, "", "Stats", "userInfo", array('user_id' => $va_download_info["user_id"]))."\"); return false;'>".$va_download_info["name"]."</a>, (".$va_download_info["email"].")</p>";
 						}
 						print "</div>";
 					}

--- a/themes/morphosource/views/Stats/stats_html.php
+++ b/themes/morphosource/views/Stats/stats_html.php
@@ -29,8 +29,9 @@
 	$va_rows = $this->getVar('rows');
 ?>
 	<div class="blueRule"><!-- empty --></div>
-	<p style="float:right; padding-top:15px;">See how your project Specimens and media have been viewed and downloaded</p>
 	<H1>Usage Stats</H1>
+	<p>Below are detailed statistics for all specimens you can edit and media groups representing these specimens. Your project membership determines edit access to specimens and media. Descriptive metadata and download usage reports are also available here. The media usage report includes all media that you can edit, as determined by project membership. The specimen media usage report includes all accessible media representing specimens you can edit. Media are accessible either if you have edit access to them, or if the media are published and publicly viewable.</p>
+	<p><b>Please note: if you have access to a large number of specimens or media, the metadata and usage statistics reports may take a long time to begin downloading. Be patient, it will happen!</b></p>
 <div id='formArea' style="margin-top:0px; padding-top:0px;">		
 		<br style="clear: both"/>
 
@@ -61,19 +62,19 @@
 					<?php print _t('Specimen'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Project(s)'); ?>
+					<?php print _t('Project'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Specimen Public Views'); ?>
+					<?php print _t('Views'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Specimen Media'); ?>
+					<?php print _t('Media'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Specimen Media Public Views'); ?>
+					<?php print _t('Media Views'); ?>
 				</th>
 				<th class="list-header-unsorted">
-					<?php print _t('Specimen Media Downloads'); ?>
+					<?php print _t('Media Downloads'); ?>
 				</th>
 				<th class="{sorter: false} list-header-nosort">&nbsp;</th>
 			</tr>
@@ -93,7 +94,7 @@
 					<?php print $va_row["specimen_views"]; ?>
 				</td>
 				<td>
-					<?php print $va_row["num_specimen_media"].(($va_row["num_specimen_media_unpublished"]) ? ", (".$va_row["num_specimen_media_unpublished"]." unpublished)" : ""); ?>
+					<?php print $va_row["num_specimen_media"]; ?>
 				</td>
 				<td>
 					<?php print $va_row["specimen_media_views"]; ?>


### PR DESCRIPTION
This PR includes a number of different changes to the ways users can access view and download usage statistics for MorphoSource media. List of changes:

- Modified ms_media_files model to support exporting media group views and media file download stats as part of standard media file metadata CSV output. Usage stats are identical to those provided by the institutional data reporting feature. The inclusion of usage stats is optional on the backend, as for large projects this metadata can take up to several minutes to generate. Unfortunately, without an overhaul to the database structure this is unavoidable. The metadata csv packaged with single media and media cart downloads does not include usage stats as a result.

-  Methods have been added to controllers for private project dashboards, public project detail pages, search, and user account-wide statistics pages to export full media file metadata and usage stats reports for a) all media owned by a project or a user and b) all (viewable) media representing specimens owned by a project or a user. 

- UI for private project dashboards, public project detail pages, and user account-wide statistics pages have been modified to be generally clearer and to provide access to usage reports. 

- Previously, the user account-wide statistics pages, search result pages, and media file pages provided potentially very different exports of metadata and usage statistics. All of these pages (as well as project pages, see above) now export the standard media file download metadata csv, along with usage stats in the case of statistics pages, search result pages, and project pages. 