### PR TITLE
Fix bugs relating to institutions in batch import workflow

### DIFF
--- a/app/controllers/MyProjects/BatchImportController.php
+++ b/app/controllers/MyProjects/BatchImportController.php
@@ -745,7 +745,19 @@
 									}
 								}
 							}elseif(in_array($vn_specimen_id, $va_idigbio_imported_specimen)){
-								$vn_idigbio_imported_specimen++;
+								$t_idb_specimen = new ms_specimens($vn_specimen_id);
+								$t_idb_specimen->set("institution_id", $this->opn_batch_institution_id);
+								$t_idb_specimen->set("user_id", $this->request->user->get("user_id"));
+								$t_idb_specimen->set("project_id", $this->opn_project_id);
+								$t_idb_specimen->set("batch_status", 1);
+								$t_idb_specimen->setMode(ACCESS_WRITE);
+								$t_idb_specimen->update();
+								if ($t_idb_specimen->numErrors()) {
+									$va_errors[$vs_row] = "There were errors saving the specimen record: ".join("; ", $t_idb_specimen->getErrors());
+									$va_rows_not_imported[] = $vs_row;
+								}else{
+									$vn_idigbio_imported_specimen++;
+								}
 							}else{
 								$vn_linked_specimen++;
 							}

--- a/app/controllers/MyProjects/InstitutionsController.php
+++ b/app/controllers/MyProjects/InstitutionsController.php
@@ -102,6 +102,7 @@
  		# -------------------------------------------------------
  		public function form() {
  			$this->view->setVar("specimen_id", $this->request->getParameter('specimen_id', pInteger));
+ 			$this->view->setVar("batch", $this->request->getParameter('batch', pInteger));
 			$this->render('Institutions/form_html.php');
  		}
  		# -------------------------------------------------------
@@ -131,6 +132,8 @@
  		}
  		# -------------------------------------------------------
  		public function save() {
+ 			$vb_batch = $this->request->getParameter('batch', pInteger);
+
 			# get names of form fields
 			$va_fields = $this->opo_item->getFormFields();
 			$va_errors = array();
@@ -180,10 +183,14 @@
 				$this->view->setVar("errors", $va_errors);
 				$this->form();
 			}else{
-				$this->opn_item_id = $this->opo_item->get($this->ops_primary_key);
-				$this->view->setVar("item_id", $this->opn_item_id);
-				$this->view->setVar("item", $this->opo_item);
-				$this->form();
+				if(!$vb_batch){
+					$this->opn_item_id = $this->opo_item->get($this->ops_primary_key);
+					$this->view->setVar("item_id", $this->opn_item_id);
+					$this->view->setVar("item", $this->opo_item);
+					$this->form();
+				}else{
+					$this->response->setRedirect(caNavUrl($this->request, "MyProjects", "BatchImport", "importSettingsForm"));
+				}
 			} 			 			
  		}
  		# -------------------------------------------------------

--- a/themes/morphosource/views/MyProjects/BatchImport/import_settings_form_html.php
+++ b/themes/morphosource/views/MyProjects/BatchImport/import_settings_form_html.php
@@ -93,7 +93,7 @@
 					var institution_id = parseInt(ui.item.id);
 					if (institution_id < 1) {
 						// nothing found...
-						jQuery("#specimenInstitutionFormContainer").load("<?php print caNavUrl($this->request, 'MyProjects', 'Institutions', 'form', array('specimen_id' => $pn_specimen_id)); ?>");
+						window.location.href = "<?php print caNavUrl($this->request, 'MyProjects', 'Institutions', 'form', array('batch' => 1)); ?>";
 					} else {
 						// found an id
 						jQuery('#institution_id').val(institution_id);

--- a/themes/morphosource/views/MyProjects/Institutions/form_html.php
+++ b/themes/morphosource/views/MyProjects/Institutions/form_html.php
@@ -3,6 +3,7 @@
 	$va_fields = $t_item->getFormFields();
 	$va_errors = $this->getVar("errors");
 	$ps_primary_key = $this->getVar("primary_key");
+	$vb_batch = $this->getVar("batch");
 	
 	# --- formatting varibales
 	# --- all fields in float_fields array  will be floated to the left
@@ -19,11 +20,19 @@ if (!$this->request->isAjax()) {
 	<div id='formArea'>
 	
 <?php
-print caFormTag($this->request, 'save', 'institutionForm', null, 'post', 'multipart/form-data', '', array('disableUnsavedChangesWarning' => true));	
+	if(!$vb_batch){
+		print caFormTag($this->request, 'save', 'institutionForm', null, 'post', 'multipart/form-data', '', array('disableUnsavedChangesWarning' => true));
+	}else{
+		print caFormTag($this->request, 'save/batch/1', 'institutionForm', null, 'post', 'multipart/form-data', '', array('disableUnsavedChangesWarning' => true));
+	}
 ?>
 	<div class="formButtons tealTopBottomRule">
 <?php
-		print "<div style='float:right;'>".caNavLink($this->request, _t("Back"), "button buttonSmall", "MyProjects", $this->request->getController(), "listItems")."</div>";
+		if(!$vb_batch){
+			print "<div style='float:right;'>".caNavLink($this->request, _t("Back"), "button buttonSmall", "MyProjects", $this->request->getController(), "listItems")."</div>";
+		}else{
+			print "<div style='float:right;'>".caNavLink($this->request, _t("Back"), "button buttonSmall", "MyProjects", "BatchImport", "importSettingsForm")."</div>";
+		}
 ?>
 		<a href="#" name="save" class="button buttonSmall" onclick="jQuery('#institutionForm').submit(); return false;"><?php print _t("Save"); ?></a>
 <?php


### PR DESCRIPTION
This PR fixes two issues reported by users in the batch import workflow:

- It is now possible to add a new institution from within the batch import workflow

- iDigBio imported specimens now properly have institution information associated with them (previously no institution was associated with iDigBio imported specimens, even when users chose institutions)