### PR TITLE
Media updates

### DIFF
--- a/app/models/ms_media.php
+++ b/app/models/ms_media.php
@@ -181,7 +181,7 @@ BaseModel::$s_ca_models_definitions['ms_media'] = array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_FIELD, 
 				'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,
 				'IS_NULL' => false, 
-				'DEFAULT' => 'originally appearing in',
+				'DEFAULT' => '',
 				'LABEL' => _t('Media citation instructions part 2'), 'DESCRIPTION' => _t('Describes how to cite this media.'),
 				'BOUNDS_LENGTH' => array(0,255)
 		),
@@ -189,7 +189,7 @@ BaseModel::$s_ca_models_definitions['ms_media'] = array(
 				'FIELD_TYPE' => FT_TEXT, 'DISPLAY_TYPE' => DT_FIELD, 
 				'DISPLAY_WIDTH' => 40, 'DISPLAY_HEIGHT' => 1,
 				'IS_NULL' => false, 
-				'DEFAULT' => ', the collection of which was funded by ',
+				'DEFAULT' => '',
 				'LABEL' => _t('Media citation instructions part 3'), 'DESCRIPTION' => _t('Describes how to cite this media.'),
 				'BOUNDS_LENGTH' => array(0,255)
 		),

--- a/themes/morphosource/views/MyProjects/Dashboard/dashboard_html.php
+++ b/themes/morphosource/views/MyProjects/Dashboard/dashboard_html.php
@@ -227,9 +227,6 @@
 				"button buttonMedium buttonWhiteBorder", "MyProjects", 
 				"Specimens", "lookupSpecimen");
 		} else if ($vs_entity_type == 'm') {
-			print caNavLink($this->request, "New Media Group", 
-				"button buttonMedium buttonWhiteBorder", "MyProjects", 
-				"Media", "form");
 			print "<a href='#' name='mediaBatchButton' ". 
 				"class='button buttonMedium buttonWhiteBorder' id='mediaBatchButton' ".
 				"title='Batch edit media groups' >Batch Edit</a>";

--- a/themes/morphosource/views/MyProjects/Media/form_html.php
+++ b/themes/morphosource/views/MyProjects/Media/form_html.php
@@ -359,7 +359,9 @@ if (!$this->request->isAjax()) {
 			# -----------------------------------------------
 			case "media_citation_instruction1":
 				print "<div class='formLabel'>";
-				print $t_item->htmlFormElement("media_citation_instruction1", "^LABEL<br>^ELEMENT")."<span style='font-weight:normal;'> provided access to these data ".$t_item->htmlFormElement("media_citation_instruction2", "^ELEMENT")." ".$t_item->htmlFormElement("media_citation_instruction3", "^ELEMENT").". The files were downloaded from www.MorphoSource.org, Duke University.";
+				print "<b>Media citation instructions</b></br>";
+				print "<p style='font-weight: normal; font-style: italic'>These fields provide a template for media citation instructions. The placeholder entries in these fields are provided as examples. They will not be saved if you do not modify them.</p>";
+				print $t_item->htmlFormElement("media_citation_instruction1", "^ELEMENT")."<span style='font-weight:normal;'> provided access to these data ".$t_item->htmlFormElement("media_citation_instruction2", "^ELEMENT")." ".$t_item->htmlFormElement("media_citation_instruction3", "^ELEMENT").". The files were downloaded from MorphoSource, Duke University (www.morphosource.org).";
 				print "</span></div>";
 			break;
 			# -----------------------------------------------
@@ -695,6 +697,11 @@ if (!$this->request->isAjax()) {
 				$('#copyrightBlock').slideUp(200);
 			}
 		});
+
+		// Add placeholder text for media citation instructions. 
+		jQuery('#media_citation_instruction1').attr("placeholder", "Jane Doe and colleagues");
+		jQuery('#media_citation_instruction2').attr("placeholder", "originally appearing in Doe et al., 2019,");
+		jQuery('#media_citation_instruction3').attr("placeholder", "with data collection funded by NSF 1234567");
 	});
 
 	var scannerListByFacilityID = <?php print json_encode($this->getVar('scannerListByFacilityID')); ?>;

--- a/themes/morphosource/views/pageFormat/pageHeader.php
+++ b/themes/morphosource/views/pageFormat/pageHeader.php
@@ -118,7 +118,6 @@
 					print "<div class='ltBlueBottomRule'>".caNavLink($this->request, _t("All download requests"), "", "MyProjects", "Dashboard", "manageAllDownloadRequests")."</div>\n";
 					print "<div>NEW:</div>";
 					print "<div>".caNavLink($this->request, _t("New Specimen"), "", "MyProjects", "Specimens", "lookupSpecimen")."</div>\n";
-					print "<div>".caNavLink($this->request, _t("New Media Group"), "", "MyProjects", "Media", "form")."</div>\n";
 					print "<div>".caNavLink($this->request, _t("New Bibliographic Citation"), "", "MyProjects", "Bibliography", "form")."</div>\n";
 					print "<div>".caNavLink($this->request, _t("New Taxonomic Name"), "", "MyProjects", "Taxonomy", "form")."</div>\n";
 					print "<div class='ltBlueBottomRule'>".caNavLink($this->request, _t("New Facility"), "", "MyProjects", "Facilities", "form")."</div>\n";


### PR DESCRIPTION
- Removes the UX paths to create a new media group not associated to a specimen.
- Removes the auto-filled default text for media group media citation instructions fields. Replaces that default text with HTML placeholders, which should give users a better indication of what should be placed in these fields without accidentally being saved as part of the record. Also added explanatory text for the media citation instructions fields. 